### PR TITLE
Add Next.js portfolio site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+.next
+out

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const sections = [
+  { id: 'about', label: 'About' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'experience', label: 'Experience' },
+  { id: 'education', label: 'Education' },
+  { id: 'contact', label: 'Contact' },
+];
+
+export default function Layout({ children }: LayoutProps) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <nav className="bg-gray-800 text-white fixed w-full z-10">
+        <div className="max-w-4xl mx-auto px-4 py-3 flex space-x-4">
+          {sections.map(({ id, label }) => (
+            <Link key={id} href={`#${id}`} className="hover:text-teal-300 transition-colors">
+              {label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+      <main className="flex-1 mt-12 px-4 max-w-4xl mx-auto w-full">
+        {children}
+      </main>
+      <footer className="bg-gray-100 text-center py-4 mt-8 text-sm text-gray-600">
+        © {new Date().getFullYear()} Ram Sankar Koripalli
+      </footer>
+    </div>
+  );
+}

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+interface SectionProps {
+  id: string;
+  title: string;
+  children: ReactNode;
+}
+
+export default function Section({ id, title, children }: SectionProps) {
+  return (
+    <section id={id} className="py-12 md:py-20">
+      <h2 className="text-3xl font-semibold mb-6" data-testid={`${id}-heading`}>
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ram797.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.8",
+    "@types/node": "^22.15.30",
+    "@types/react": "^19.1.6",
+    "autoprefixer": "^10.4.21",
+    "gray-matter": "^4.0.3",
+    "next": "^15.3.3",
+    "postcss": "^8.5.4",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tailwindcss": "^4.1.8",
+    "typescript": "^5.8.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import path from 'path';
+import matter from 'gray-matter';
+import Image from 'next/image';
+import ramImg from '../data/ram.jpg';
+import aggieImg from '../data/aggiepark.jpg';
+import Layout from '../components/Layout';
+import Section from '../components/Section';
+
+interface Resume {
+  name: string;
+  title: string;
+  summary: string;
+  contact: { email: string; phone: string; linkedin: string; github: string };
+  skills: { languages: string[]; frameworks: string[]; tools: string[] };
+  projects: { title: string; dates?: string; description?: string; link?: string }[];
+  experience: { company: string; role: string; location: string; dates: string; bullets: string[] }[];
+  education: { school: string; degree: string; dates: string; gpa?: string; cgpa?: string }[];
+}
+
+export async function getStaticProps() {
+  const file = fs.readFileSync(path.join(process.cwd(), 'data/resume.md'), 'utf8');
+  const { data } = matter(file);
+  return { props: { resume: data as Resume } };
+}
+
+type Props = {
+  resume: Resume;
+};
+
+export default function Home({ resume }: Props) {
+  const { name, title, summary, contact, skills, projects, experience, education } = resume;
+  return (
+    <Layout>
+      <header className="flex flex-col items-center text-center py-20" id="hero">
+        <Image src={ramImg} alt={name} width={160} height={160} className="rounded-full" />
+        <h1 className="text-4xl font-bold mt-4">{name}</h1>
+        <h2 className="text-xl text-gray-600 mt-2">{title}</h2>
+        <p className="mt-4 max-w-xl">{summary}</p>
+      </header>
+
+      <Section id="about" title="About">
+        <p>{summary}</p>
+      </Section>
+
+      <Section id="skills" title="Skills">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <h3 className="font-medium">Languages</h3>
+            <ul className="list-disc list-inside">
+              {skills.languages.map((s) => (
+                <li key={s}>{s}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-medium">Frameworks</h3>
+            <ul className="list-disc list-inside">
+              {skills.frameworks.map((s) => (
+                <li key={s}>{s}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-medium">Tools</h3>
+            <ul className="list-disc list-inside">
+              {skills.tools.map((s) => (
+                <li key={s}>{s}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </Section>
+
+      <Section id="projects" title="Projects">
+        {projects.map((proj) => (
+          <div key={proj.title} className="mb-6">
+            <h3 className="text-lg font-semibold">
+              {proj.link ? (
+                <a href={proj.link} className="text-teal-600 hover:underline" target="_blank" rel="noopener noreferrer">
+                  {proj.title}
+                </a>
+              ) : (
+                proj.title
+              )}
+            </h3>
+            {proj.dates && <p className="text-sm text-gray-500">{proj.dates}</p>}
+            <p>{proj.description}</p>
+          </div>
+        ))}
+      </Section>
+
+      <Section id="experience" title="Experience">
+        {experience.map((exp) => (
+          <div key={exp.company + exp.role} className="mb-8">
+            <h3 className="font-semibold">
+              {exp.role} – {exp.company}
+            </h3>
+            <p className="text-sm text-gray-500">
+              {exp.location} | {exp.dates}
+            </p>
+            <ul className="list-disc list-inside mt-2 space-y-1">
+              {exp.bullets.map((b, i) => (
+                <li key={i}>{b}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </Section>
+
+      <Section id="education" title="Education">
+        <div className="space-y-6">
+          {education.map((edu) => (
+            <div key={edu.school} className="">
+              <h3 className="font-semibold">{edu.school}</h3>
+              <p className="text-sm text-gray-500">{edu.degree} | {edu.dates}</p>
+              {edu.gpa && <p>GPA: {edu.gpa}</p>}
+              {edu.cgpa && <p>CGPA: {edu.cgpa}</p>}
+            </div>
+          ))}
+        </div>
+        <div className="mt-6">
+          <Image src={aggieImg} alt="Aggie Park" width={800} height={450} className="rounded" />
+        </div>
+      </Section>
+
+      <Section id="contact" title="Contact">
+        <ul className="space-y-2">
+          <li>Email: <a href={`mailto:${contact.email}`} className="text-teal-600 hover:underline">{contact.email}</a></li>
+          <li>Phone: {contact.phone}</li>
+          <li><a href={contact.linkedin} className="text-teal-600 hover:underline">LinkedIn</a></li>
+          <li><a href={contact.github} className="text-teal-600 hover:underline">GitHub</a></li>
+        </ul>
+      </Section>
+    </Layout>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./pages/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- configure Next.js with Tailwind CSS
- add generic Section component and page layout
- load resume data for portfolio content
- remove duplicate images and import originals from `data`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844c99599b88331921a7bd203cab4fa